### PR TITLE
Add AppWorld

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Date is based on arxiv v1. They do not represent all language agent work, and we
 * (2024-03) [LLM3:Large Language Model-based Task and Motion Planning with Motion Failure Reasoning.](https://arxiv.org/abs/2403.11552) (planning, reasoning)
 * (2024-04) [Empowering Biomedical Discovery with AI Agents](https://arxiv.org/abs/2404.02831) (AI scientist, biomedical research)
 * (2024-05) [TimeChara: Evaluating Point-in-Time Character Hallucination of Role-Playing Large Language Models](https://arxiv.org/abs/2405.18027) (reasoning, retrieval)
+* (2024-07) [AppWorld: A Controllable World of Apps and People for Benchmarking Interactive Coding Agents](https://arxiv.org/abs/2407.18901) (environment, planning, grounding, reflection, reasoning, retrieval)
 
 
 (more to be added soon. pull request welcome.)


### PR DESCRIPTION
Hey @ysymyth ! Thanks for setting up this repository and also writing many cool papers in the space!

Please consider adding 🌎 [AppWorld](https://appworld.dev/) to this list. The environment tag should definitely be there. The other tags are based on the one/some of the baselines we had in the paper.

**TLDR**: Introduces the AppWorld Engine, a high-fidelity execution environment of 9 day-to-day apps, operable via 457 APIs, populated with digital activities of 106 people living in a simulated world, and an associated benchmark of natural, diverse, and challenging autonomous agent tasks requiring rich and interactive coding. The tasks have robust programmatic evaluation with state and execution-based unit tests.